### PR TITLE
Ermögliche das Ignorieren von Ordnern beim Bauen

### DIFF
--- a/src/build/build.js
+++ b/src/build/build.js
@@ -36,8 +36,16 @@ export const build = (paths, targetFolder, extraConverters) => {
         }
     }
 
+    let ignoreFolders = readJSONFile(CONFIG_FILE).ignoreFolders;
+    if (ignoreFolders === undefined) {
+        ignoreFolders = [];
+    }
+
     // Delete all files and folders below target folder, so we don't get any artifacts from previous builds
     for (const path of readdirSync(targetFolder)) {
+        if (ignoreFolders.includes(path)) {
+            continue;
+        }
         rmSync(targetFolder + "/" + path, { recursive: true });
     }
 
@@ -64,6 +72,9 @@ export const build = (paths, targetFolder, extraConverters) => {
     };
 
     for (const file of paths) {
+        if (ignoreFolders.includes(file)) {
+            continue;
+        }
         recursiveCopy(file);
     }
 


### PR DESCRIPTION
Diese Ordner werden dann weder gelöscht noch kopiert und bleiben auf dem aktuellen Stand. Praktisch um beispielsweise den "packs"-Ordner eines Abenteuers beim Livetest in Ruhe zu lassen während man den Code anpasst und nicht jedes mal Foundry neustarten muss :)

Einschränkung: Funktioniert aktuell nur mit Top-Level-Ordnern und nicht mit verschachtelten Ordnern.

Verwendungsbeispiel:
````
{
    "buildPath": "C:\\Users\\niels\\AppData\\Local\\FoundryVTT\\Data\\modules\\pf2e-zda",
    "ignoreFolders": [ "packs" ]
}