### PR TITLE
Fixe Größe von Szenentokens beim Import

### DIFF
--- a/src/importer/adventure-importer.js
+++ b/src/importer/adventure-importer.js
@@ -1,4 +1,4 @@
-import { ACTOR_REDIRECTS } from '../pack-extractor/constants.js';
+import { ACTOR_REDIRECTS } from "../pack-extractor/constants.js";
 
 const keepImportPrefix = "[keep-on-import]";
 
@@ -21,20 +21,18 @@ const getRemasterSourceID = (originalSourceID) => {
             remasterMap[actorEntry.linkOld] = actorEntry.linkNew;
         }
     }
-    const splitID = originalSourceID.split('.');
+    const splitID = originalSourceID.split(".");
     if (splitID.length === 4) {
-        splitID.splice(3, 0, 'Actor');
+        splitID.splice(3, 0, "Actor");
     }
-    const checkID = splitID.join('.');
+    const checkID = splitID.join(".");
 
     if (remasterMap[checkID]) {
         return remasterMap[checkID];
-    }
-    else {
+    } else {
         return originalSourceID;
     }
-
-}
+};
 
 const getPackData = (document) => {
     // Skip actors without sourceId

--- a/src/importer/adventure-importer.js
+++ b/src/importer/adventure-importer.js
@@ -2,6 +2,16 @@ import { ACTOR_REDIRECTS } from '../pack-extractor/constants.js';
 
 const keepImportPrefix = "[keep-on-import]";
 
+// Based on ActorSizePF2e from PF2e system: https://github.com/foundryvtt/pf2e/blob/940278c8f6efc687b59098688293ce24f24df228/src/module/actor/data/size.ts#L55
+const defaultSpaces = {
+    tiny: { long: 2.5, wide: 2.5 },
+    sm: { long: 5, wide: 5 },
+    med: { long: 5, wide: 5 },
+    lg: { long: 10, wide: 10 },
+    huge: { long: 15, wide: 15 },
+    grg: { long: 20, wide: 20 },
+}
+
 let remasterMap = null;
 
 const getRemasterSourceID = (originalSourceID) => {
@@ -70,6 +80,7 @@ export const registerAdventureImporter = (packName) => {
         if (adventure.pack != packName) {
             return true;
         }
+        const updatedActors = new Map();
         let count = 0;
         for (const container of [toCreate, toUpdate]) {
             count++;
@@ -145,6 +156,30 @@ export const registerAdventureImporter = (packName) => {
                         rules: sourceData.rules,
                         "flags.core.sourceId": source.uuid,
                     });
+                    updatedActors.set(actor._id, actor);
+                }
+            }
+        }
+        // Update actors in scenes based on updated actors
+        for (const container of [toCreate, toUpdate]) {
+            if (container.Scene) {
+                for (const scene of container.Scene) {
+                    if (scene.tokens) {
+                        for (const token of scene.tokens) {
+                            if (updatedActors.has(token.actorId)) {
+                                const actor = updatedActors.get(token.actorId);
+                                const spaces = defaultSpaces[actor?.system?.traits?.size?.value];
+                                if (!spaces) {
+                                    continue;
+                                }
+                                foundry.utils.mergeObject(token, {
+                                    height: spaces.long / 5,
+                                    width: spaces.wide / 5,
+                                    actorLink: true,
+                                });
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Scheinbar läuft PF2e nicht einfach über die height/width vom prototypeToken sondern nutzt da ein eigenes System, das hier verwendet werden muss... Jetzt klappt es aber